### PR TITLE
feat: add local authority selection to property creation form

### DIFF
--- a/src/app/(app)/property/create/components/property-forms.tsx
+++ b/src/app/(app)/property/create/components/property-forms.tsx
@@ -7,6 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import {
   legalRepresentatives,
+  localAuthorities,
   PropertyInput,
   propertyTypes
 } from '@/lib/validations/property-schema';
@@ -75,10 +76,10 @@ export const PropertyDetails = ({ form }: IForm) => (
       />
     </div>
     <div className="grid w-full grid-cols-3 gap-2">
-      <Input
-        type="text"
-        label="local authority"
-        placeholder=""
+      <SelectInput
+        label="Local Authority"
+        placeholder="select"
+        options={localAuthorities}
         {...form.register('local_authority')}
       />
       <Input

--- a/src/lib/validations/property-schema.ts
+++ b/src/lib/validations/property-schema.ts
@@ -140,3 +140,39 @@ export const legalRepresentatives: { label: string; value: string }[] = [
     value: 'Capital & Counties Legal Associates'
   }
 ];
+
+export const localAuthorities: { label: string; value: string }[] = [
+  {
+    label: 'Greenwich Council',
+    value: 'Greenwich Council'
+  },
+  {
+    label: 'St Albans City and District Council',
+    value: 'St Albans City and District Council'
+  },
+
+  {
+    label: 'West Herts District Council',
+    value: 'West Herts District Council'
+  },
+  {
+    label: 'East London District Council',
+    value: 'East London District Council'
+  },
+  {
+    label: 'Croydon District Council',
+    value: 'Croydon District Council'
+  },
+  {
+    label: 'Battersea District Council',
+    value: 'Battersea District Council'
+  },
+  {
+    label: 'Borehamwood, Hertfordshire',
+    value: 'Borehamwood, Hertfordshire'
+  },
+  {
+    label: 'City of London Council',
+    value: 'City of London Council'
+  }
+];


### PR DESCRIPTION
- Replaced the text input for local authority with a dropdown select input.
- Introduced a new localAuthorities array in the validation schema containing various council options.